### PR TITLE
msal 1.34.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "msal" %}
-{% set version = "1.33.0" %}
+{% set version = "1.34.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 836ad80faa3e25a7d71015c990ce61f704a87328b1e73bcbb0623a18cbf17510
+  sha256: 76ba83b716ea5a6d75b0279c0ac353a0e05b820ca1f6682c0eb7f45190c43c2f
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - python
     - requests >=2.0.0,<3
     - pyjwt >=1.0.0,<3
-    - cryptography >=2.5,<48
+    - cryptography >=2.5,<49
   run_constrained:
     - pymsalruntime >=0.14,<0.19  # [py>36 and win]
     - pymsalruntime >=0.17,<0.19  # [py>38 and osx]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10951) 
- [Upstream repository](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.34.0/setup.cfg)

### Explanation of changes:

- Skip py<38
- Update runtime pinnings

### Notes:

-